### PR TITLE
feat(collection): add reactive supplementary visibility modifiers

### DIFF
--- a/Sources/Construkt/Core/Builder/CollectionView/Builder+AnySection.swift
+++ b/Sources/Construkt/Core/Builder/CollectionView/Builder+AnySection.swift
@@ -554,8 +554,72 @@ public struct AnySection: AnySectionObservable {
              }
          }
          return AnySection(binding: improved)
-     }
-    
+      }
+
+    /// Hides or shows the section header reactively using a boolean binding.
+    ///
+    /// - Important: This uses `distinctUntilChanged` to avoid unnecessary section updates when the
+    ///   incoming visibility value repeats.
+    public func headerHidden<B: ViewBinding>(when hiddenBinding: B) -> AnySection where B.Value == Bool {
+        let hidden = hiddenBinding.distinctUntilChanged()
+
+        let improved = AnyViewBinding<([SectionConfig], Bool)>
+            .combineLatest(binding, hidden)
+            .map { sections, isHidden in
+                sections.map { section in
+                    let updatedHeader = isHidden ? nil : section.header
+
+                    if (section.header == nil) == (updatedHeader == nil), section.header?.id == updatedHeader?.id {
+                        return section
+                    }
+
+                    return SectionConfig(
+                        identifier: section.identifier,
+                        cells: section.cells,
+                        header: updatedHeader,
+                        footer: section.footer,
+                        layoutProvider: section.layoutProvider,
+                        layoutModifiers: section.layoutModifiers,
+                        decorationProviders: section.decorationProviders
+                    )
+                }
+            }
+
+        return AnySection(binding: improved)
+    }
+
+    /// Hides or shows the section footer reactively using a boolean binding.
+    ///
+    /// - Important: This uses `distinctUntilChanged` to avoid unnecessary section updates when the
+    ///   incoming visibility value repeats.
+    public func footerHidden<B: ViewBinding>(when hiddenBinding: B) -> AnySection where B.Value == Bool {
+        let hidden = hiddenBinding.distinctUntilChanged()
+
+        let improved = AnyViewBinding<([SectionConfig], Bool)>
+            .combineLatest(binding, hidden)
+            .map { sections, isHidden in
+                sections.map { section in
+                    let updatedFooter = isHidden ? nil : section.footer
+
+                    if (section.footer == nil) == (updatedFooter == nil), section.footer?.id == updatedFooter?.id {
+                        return section
+                    }
+
+                    return SectionConfig(
+                        identifier: section.identifier,
+                        cells: section.cells,
+                        header: section.header,
+                        footer: updatedFooter,
+                        layoutProvider: section.layoutProvider,
+                        layoutModifiers: section.layoutModifiers,
+                        decorationProviders: section.decorationProviders
+                    )
+                }
+            }
+
+        return AnySection(binding: improved)
+    }
+     
     /// Adds decoration items to the section's layout.
     public func decorationItems(_ items: [NSCollectionLayoutDecorationItem]) -> AnySection {
         let improved = binding.map { sections in

--- a/Tests/ConstruktTests/AnySectionSupplementaryVisibilityTests.swift
+++ b/Tests/ConstruktTests/AnySectionSupplementaryVisibilityTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import ConstruktKit
+
+@Suite("AnySection Supplementary Visibility")
+@MainActor
+struct AnySectionSupplementaryVisibilityTests {
+
+    @Test("headerHidden updates only when visibility changes")
+    func headerHiddenUpdatesOnlyOnVisibilityChanges() {
+        let bag = CancelBag()
+        let hidden = Property(false)
+        var emissions: [[SectionConfig]] = []
+
+        AnySection(
+            id: VisibilitySection.header
+        ) {
+            Header(id: "header-id") {
+                ContainerView()
+            }
+            AnyCell("A", id: "A") { _ in
+                ContainerView()
+            }
+        }
+        .headerHidden(when: hidden)
+        .asAnySectionObservable()
+        .observe(on: nil) { sections in
+            emissions.append(sections)
+        }
+        .store(in: bag)
+
+        #expect(emissions.count == 1)
+        #expect(emissions[0].count == 1)
+        #expect(emissions[0][0].header?.id as? String == "header-id")
+
+        hidden.wrappedValue = false
+        #expect(emissions.count == 1)
+
+        hidden.wrappedValue = true
+        #expect(emissions.count == 2)
+        #expect(emissions[1][0].header == nil)
+
+        hidden.wrappedValue = true
+        #expect(emissions.count == 2)
+
+        hidden.wrappedValue = false
+        #expect(emissions.count == 3)
+        #expect(emissions[2][0].header?.id as? String == "header-id")
+    }
+
+    @Test("footerHidden updates only when visibility changes")
+    func footerHiddenUpdatesOnlyOnVisibilityChanges() {
+        let bag = CancelBag()
+        let hidden = Property(false)
+        var emissions: [[SectionConfig]] = []
+
+        AnySection(
+            id: VisibilitySection.footer
+        ) {
+            Footer(id: "footer-id") {
+                ContainerView()
+            }
+            AnyCell("A", id: "A") { _ in
+                ContainerView()
+            }
+        }
+        .footerHidden(when: hidden)
+        .asAnySectionObservable()
+        .observe(on: nil) { sections in
+            emissions.append(sections)
+        }
+        .store(in: bag)
+
+        #expect(emissions.count == 1)
+        #expect(emissions[0].count == 1)
+        #expect(emissions[0][0].footer?.id as? String == "footer-id")
+
+        hidden.wrappedValue = false
+        #expect(emissions.count == 1)
+
+        hidden.wrappedValue = true
+        #expect(emissions.count == 2)
+        #expect(emissions[1][0].footer == nil)
+
+        hidden.wrappedValue = true
+        #expect(emissions.count == 2)
+
+        hidden.wrappedValue = false
+        #expect(emissions.count == 3)
+        #expect(emissions[2][0].footer?.id as? String == "footer-id")
+    }
+}
+
+private enum VisibilitySection: SectionConfigIdentifier {
+    case header
+    case footer
+
+    var uniqueId: String { "supplementary-\(self)" }
+}


### PR DESCRIPTION
Introduce AnySection.headerHidden(when:) and footerHidden(when:) so section supplementary views can be toggled with ViewBinding without custom layout branching.

Use distinctUntilChanged to avoid redundant visibility updates and add focused tests validating header/footer hide-show behavior and stable emissions.